### PR TITLE
[ScrollTo 안되는 문제 해결] globall.css 수정 

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -2,13 +2,12 @@ html,
 body {
   margin: 0;
   width: 100%;
-  height: 100%;
+  min-height: 100%;
   overflow-x: hidden;
 }
 
 #root {
   margin: 0;
   width: 100%;
-  height: 100%;
-  overflow-x: hidden;
+  min-height: 100%;
 }


### PR DESCRIPTION
## 👩🏻‍💻 작업사항

global.css의 ```overflow-x:hidden```은 유지한채로 ```Barup```도 작동하도록 수정했습니다. 
