### PR TITLE
[사이드바] 찜 목록 자동 업데이트 & navigate 추가 

### DIFF
--- a/src/components/Nav/SideBar.js
+++ b/src/components/Nav/SideBar.js
@@ -1,9 +1,8 @@
 import { useEffect } from "react";
+import { useNavigate } from "react-router-dom";
 import styled, { css } from "styled-components";
 import ic_user from "../../assets/icon/topnavbar/ic_user.png";
 import ic_heart from "../../assets/icon/topnavbar/ic_heart.png";
-
-import food1 from "../../assets/food/food1.jpg";
 
 const Sidebar = ({ isOpen, heartList, userInfo }) => {
   // const test = {
@@ -13,6 +12,11 @@ const Sidebar = ({ isOpen, heartList, userInfo }) => {
   //   name: "이펍떡볶이",
   //   imageUrl: "https://efub/?img=14",
   // };
+
+  const navigate = useNavigate();
+  const _handleGotoStore = storeId => {
+    navigate(`/detail/${storeId}`);
+  };
 
   return (
     <Div isOpen={isOpen}>
@@ -27,7 +31,7 @@ const Sidebar = ({ isOpen, heartList, userInfo }) => {
 
       <HeartListContainer>
         {heartList?.map(h => (
-          <HeartBox key={h.storeId}>
+          <HeartBox key={h.storeId} onClick={() => _handleGotoStore(h.storeId)}>
             <HeartImgBox img={h.imageUrl}>
               <img src={ic_heart} />
             </HeartImgBox>

--- a/src/components/Nav/TopNavbar.js
+++ b/src/components/Nav/TopNavbar.js
@@ -20,9 +20,10 @@ import { GetUserInfo } from "../../api/user";
  *  2. title : 중앙에 들어가는 굵은 글씨 타이틀
  *  3. subTitle : title 밑에 들어가는 서브 텍스트
  *  4. subTitleColor : subTitle의 색상코드. 디폴트는 색상은 #151515
+ *  5. updateTime : 찜 리스트 요청 시간. updateTime이 달라질 때 마다 찜 목록 업데이트
  */
 
-const TopNavbar = ({ noTitle, title, subTitle, subTitleColor }) => {
+const TopNavbar = ({ noTitle, title, subTitle, subTitleColor, updateTime }) => {
   const [sidebarOpen, setSideberOpen] = useState(false); // 사이드바 open 여부
   const [heartList, setHeartList] = useState([]); // 찜 목록
   const [userInfo, setUserInfo] = useState(null);
@@ -51,16 +52,13 @@ const TopNavbar = ({ noTitle, title, subTitle, subTitleColor }) => {
   /** 내 찜 목록 불러오는 비동기 함수 */
   const _reqGetMyHeartsList = async () => {
     const res = await GetMyHeartListAPI();
-    console.log(res);
+    console.log("찜목록", res);
     setHeartList(res);
   };
 
   useEffect(() => {
     // 뒷 배경 클릭 시 자동으로 사이드바 닫힘
     document.addEventListener("click", _handleCloseSidebar, true);
-
-    // 찜 목록 불러오기
-    _reqGetMyHeartsList();
     // 유저 정보 불러오기
     _reqGetUserInfo();
 
@@ -68,6 +66,12 @@ const TopNavbar = ({ noTitle, title, subTitle, subTitleColor }) => {
       document.removeEventListener("click", _handleCloseSidebar, true); // clean up
     };
   }, []);
+
+  useEffect(() => {
+    // 찜 목록 불러오기
+    _reqGetMyHeartsList();
+    console.log("찜 목록 요청");
+  }, [updateTime]);
 
   /** 사이드바 열었을 때 배경 스크롤 방지 */
   useEffect(() => {

--- a/src/pages/MainPage.js
+++ b/src/pages/MainPage.js
@@ -15,7 +15,6 @@ const MainPage = () => {
   return (
     <Div>
       <TopNavbar noTitle />
-
       <Logo src={logo} />
 
       <Container>


### PR DESCRIPTION
## 👩🏻‍💻 작업사항

**1. 사이드바의 찜 목록을 동기화 하기 위한 props를 추가했습니다.**
```javascript
const TopNavbar = ({ noTitle, title, subTitle, subTitleColor, updateTime }) => {
....


  useEffect(() => {
    // 찜 목록 불러오기
    _reqGetMyHeartsList();
    console.log("찜 목록 요청");
  }, [updateTime]);
```

다음과 같이 테스트 할 수 있습니다. Topbar의 updateTime에 변화가 생기면 찜 목록을 다시 불러옵니다. 
![image](https://github.com/mango-plate-clone/Mango-front/assets/81161750/2f1a52df-2623-472a-be29-bb1bfd912ff6)


**3. 사이드바의 가게 썸네일을 누르면 ```/detail/1``` 페이지로  이동합니다.** 
```javascript
 <HeartBox key={h.storeId} onClick={() => _handleGotoStore(h.storeId)}>
            <HeartImgBox img={h.imageUrl}>
              <img src={ic_heart} />
            </HeartImgBox>
            <p>{h.name}</p>
          </HeartBox>
```
