### PR TITLE
:lipstick: review page 사이드바 overflow 문제 해결

### DIFF
--- a/src/components/Review/ReviewResult.js
+++ b/src/components/Review/ReviewResult.js
@@ -167,7 +167,7 @@ export default ReviewResult;
 // 리뷰 부분
 const Img = styled.img``;
 const ReviewTitle = styled.div`
-  width: 100%;
+  width: 90%;
   display: flex;
   justify-content: space-between;
   /* align-items: center; */
@@ -210,7 +210,7 @@ const DownIcon = styled.img`
 `;
 
 const ReviewItem = styled.div`
-  width: 100%;
+  width: 90%;
   background: #f4f4f4;
   border-radius: 32px;
   margin-top: 12px;

--- a/src/components/Review/StarRate.js
+++ b/src/components/Review/StarRate.js
@@ -74,7 +74,7 @@ export default StarRate;
 const Img = styled.img``;
 // 별점 부분
 const StarRateInfo = styled.div`
-  width: 100%;
+  width: 90%;
   height: 120px;
   background: #f4f4f4;
   border-radius: 32px;

--- a/src/pages/ReviewPage.js
+++ b/src/pages/ReviewPage.js
@@ -24,14 +24,16 @@ const ReviewPage = () => {
 export default ReviewPage;
 
 const Div = styled.div`
-  width: 90%;
+  /* width: 90%; */
+  width: 100%;
   height: 100%;
 
   display: flex;
   flex-direction: column;
   align-items: center;
   // justify-content: center;
-  margin: 0 5%;
+  /* margin: 0 5%; */
+  overflow-x: hidden;
 
   font-family: "Pretendard";
   overflow-y: scroll;


### PR DESCRIPTION
## 👩🏻‍💻 작업사항

리뷰 페이지에서 가로로 스크롤바가 생기면서 user 이미지 버튼을 누르지 않아도 스크롤만 하면 오른쪽 사이드바가 보이는 문제가 있었습니다.
리뷰 페이지에서만 overflow-x : hidden; 처리해서 문제를 해결했습니다.

## 💫 추가 코멘트

혹시 기능적인 문제가 발생할 경우 알려주세요!

### 테스트 결과

- 수정 전
![image](https://github.com/mango-plate-clone/Mango-front/assets/81233784/b30f6b5f-a8f5-4dee-ba90-a2923547a32f)

- 수정 후
![image](https://github.com/mango-plate-clone/Mango-front/assets/81233784/e98df539-6939-42b2-9d1d-24faded49238)
